### PR TITLE
Add colors to the showcase

### DIFF
--- a/test/components/previews/colors_preview.rb
+++ b/test/components/previews/colors_preview.rb
@@ -1,0 +1,15 @@
+class ColorsPreview < Lookbook::Preview
+  def all
+    colors_css_path = Rails.application.assets.reveal(:path).find do
+      it.to_s.end_with?("css-zero/colors.css")
+    end
+    contents = File.read(colors_css_path)
+    variable_names = contents.scan(/(--[^:]+):/).map { it[0] }
+
+    # A hash like so:
+    # { "Slate" => ["--slate-50", ...], "Neutral" => ["--neutral-50", ...] }
+    groups = variable_names.group_by { it.match("--([^-]+)")[1].capitalize }
+
+    render template: "colors_preview/all", assigns: { groups: groups }
+  end
+end

--- a/test/components/previews/colors_preview/all.html.erb
+++ b/test/components/previews/colors_preview/all.html.erb
@@ -1,0 +1,10 @@
+<div class="flex flex-row flex-wrap gap">
+  <% @groups.each do |group_name, variables| %>
+    <div>
+      <h2 class="text-xl"><%= group_name %></h2>
+      <% variables.each do |variable| %>
+        <div style="background: var(<%= variable %>)" class="p-2 pi-10"></div>
+      <% end %>
+    </div>
+  <% end %>
+</div>


### PR DESCRIPTION
Hi, thanks for making CSS Zero! I found it hard to visualize what each of the colors look like, and I think putting it in the showcase would help.

This code reads the colors straight from the `colors.css` file, so it's never out of date. It's slightly tricky, though, so hardcoding it could also make sense.

## Screenshots

### Colors

![colors](https://github.com/user-attachments/assets/74ab70d8-5a8a-4614-8506-a55f432e1f8e)

### HTML source

![html](https://github.com/user-attachments/assets/516e4f1a-fad6-4931-82c5-94b5e288669e)

