### PR TITLE
Add missing closing tag for span in mobile menu partial

### DIFF
--- a/app/views/lookbook/preview/_mobile_menu.html.erb
+++ b/app/views/lookbook/preview/_mobile_menu.html.erb
@@ -1,6 +1,6 @@
 <div class="hide@md" data-controller="dialog">
   <button type="button" class="btn btn--icon" data-action="dialog#showModal">
-    <span class="icon icon--menu" style="--icon-size: 1.25rem" aria-hidden="true">
+    <span class="icon icon--menu" style="--icon-size: 1.25rem" aria-hidden="true"></span>
     <span class="sr-only">Open menu</span>
   </button>
 


### PR DESCRIPTION
I found this tiny mistake when I copy-pasted the partial to one of my projects.

Thank you for CSS Zero!